### PR TITLE
Change offsetExists to use array_key_exists

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -24,7 +24,7 @@ class Entity implements \ArrayAccess {
     }
 
     public function offsetExists($offset): bool {
-        return isset($this->entity[$offset]);
+        return array_key_exists($offset, $this->entity);
     }
 
     public function offsetGet($offset) {


### PR DESCRIPTION
With the current implementation of `offsetExists`, you cannot update a field which is null in the original object, as isset returns false for this.

Before:

```
$site = $client->getSites()[0];  // Site has no region
$site['region'] = 123;    // Throws exception as below
```

> Uncaught Exception ND\Netbox\Exception: "unknown key 'region' possible values id,url,display,name,slug,status,region,group,tenant,facility,time_zone,description,physical_address,shipping_address,latitude,longitude,comments,asns,tags,custom_fields,created,last_updated,circuit_count,device_count,prefix_count,rack_count,virtualmachine_count,vlan_count" at /srv/www/sites/mist/vendor/ndamiens/netbox-client-php/src/Entity.php line 42

This PR changes the implementation to use `array_key_exists` rather than `isset`