### PR TITLE
Add getCollection and getSingle on Client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,27 +70,27 @@ class Client {
     }
 
     public function getInterface(int $interface_id): Entity {
-        return $this->getSingle(sprintf("/api/dcim/interfaces/?id=%d", $interface_id));
+        return $this->getSingle(sprintf("/api/dcim/interfaces/%d", $interface_id));
     }
 
     public function getTenants(): Collection {
-        return $this->getCollection("/api/tenancy/tenants");
+        return $this->getCollection("/api/tenancy/tenants/");
     }
 
     public function getTenant(int $tenant_id): Entity {
-        return $this->getSingle(sprintf("/api/tenancy/tenants/?id=%d", $tenant_id));
+        return $this->getSingle(sprintf("/api/tenancy/tenants/%d", $tenant_id));
     }
 
     public function getSites(): Collection {
-        return $this->getCollection("/api/dcim/sites");
+        return $this->getCollection("/api/dcim/sites/");
     }
 
     public function getSite(int $site_id): Entity {
-        return $this->getSingle(sprintf("/api/dcim/sites/?id=%d", $site_id));
+        return $this->getSingle(sprintf("/api/dcim/sites/%d", $site_id));
     }
 
     public function getVlan(int $vlan_id): Entity {
-        return $this->getSingle(sprintf("/api/ipam/vlans/?id=%d", $vlan_id));
+        return $this->getSingle(sprintf("/api/ipam/vlans/%d", $vlan_id));
     }
 
     public function getApiUrl(): string {
@@ -139,7 +139,7 @@ class Client {
      * @return Collection
      */
     public function deviceCables(int $device_id): Collection {
-        return $this->getCollection(sprintf("/api/dcim/cables?device_id=%d", $device_id));
+        return $this->getCollection(sprintf("/api/dcim/cables/?device_id=%d", $device_id));
     }
-    
+
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,6 +36,24 @@ class Client {
         return $this->getGuzzleClient()->get($url);
     }
 
+    /**
+     * Gets a NetBox API and returns a Collection from it
+     * @param string $url
+     * @return Collection
+     */
+    public function getCollection($url): Collection {
+        $q = $this->getGuzzleClient()->request("GET", sprintf("%s%s", $this->api_url, $url));
+        return new Collection($this, $q);
+    }
+
+    /**
+     * Gets a NetBox API which returns a collection of one, and returns the Entity from it
+     */
+    public function getSingle($url): Entity {
+        $collection = $this->getCollection($url);
+        return $collection->current();
+    }
+
     public function devices(?array $device_roles = null): Collection {
         $roles = [];
         if (is_array($device_roles)) {
@@ -48,48 +66,31 @@ class Client {
     }
 
     public function deviceInterfaces(int $device_id): Collection {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/dcim/interfaces/?device_id=%d", $this->api_url, $device_id));
-        return new Collection($this, $q);
+        return $this->getCollection(sprintf("/api/dcim/interfaces/?device_id=%d", $device_id));
     }
 
     public function getInterface(int $interface_id): Entity {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/dcim/interfaces/?id=%d", $this->api_url, $interface_id));
-        return (new Collection($this, $q))->current();
+        return $this->getSingle(sprintf("/api/dcim/interfaces/?id=%d", $interface_id));
     }
 
     public function getTenants(): Collection {
-        $q = $this->getGuzzleClient()->request("GET", $this->api_url . "/api/tenancy/tenants");
-        return new Collection($this, $q);
+        return $this->getCollection("/api/tenancy/tenants");
     }
 
     public function getTenant(int $tenant_id): Entity {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/tenancy/tenants/?id=%d", $this->api_url, $tenant_id));
-        return (new Collection($this, $q))->current();
+        return $this->getSingle(sprintf("/api/tenancy/tenants/?id=%d", $tenant_id));
     }
 
     public function getSites(): Collection {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/dcim/sites", $this->api_url));
-        return new Collection($this, $q);
+        return $this->getCollection("/api/dcim/sites");
     }
 
-    /**
-     * Get one site by id
-     * @param int $site_id
-     * @return Entity
-     */
     public function getSite(int $site_id): Entity {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/dcim/sites/?id=%d", $this->api_url, $site_id));
-        return (new Collection($this, $q))->current();
+        return $this->getSingle(sprintf("/api/dcim/sites/?id=%d", $site_id));
     }
 
-    /**
-     * Get one vlan by id (netbox)
-     * @param int $vlan_id
-     * @return Entity
-     */
     public function getVlan(int $vlan_id): Entity {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/ipam/vlans/?id=%d", $this->api_url, $vlan_id));
-        return (new Collection($this, $q))->current();
+        return $this->getSingle(sprintf("/api/ipam/vlans/?id=%d", $vlan_id));
     }
 
     public function getApiUrl(): string {
@@ -102,8 +103,7 @@ class Client {
      * @return Collection
      */
     public function groupVlans(int $group_id): Collection {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/ipam/vlans/?group_id=%d", $this->api_url, $group_id));
-        return (new Collection($this, $q));
+        return $this->getCollection(sprintf("/api/ipam/vlans/?group_id=%d", $group_id));
     }
 
     /**
@@ -139,8 +139,7 @@ class Client {
      * @return Collection
      */
     public function deviceCables(int $device_id): Collection {
-        $q = $this->getGuzzleClient()->request("GET", sprintf("%s/api/dcim/cables?device_id=%d", $this->api_url, $device_id));
-        return (new Collection($this, $q));
+        return $this->getCollection(sprintf("/api/dcim/cables?device_id=%d", $device_id));
     }
-
+    
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -22,12 +22,21 @@ class Collection implements \Iterator, \Countable {
             throw new Exception("netbox err" . $response->getStatusCode() . " " . $response->getReasonPhrase());
         }
         $resp = json_decode($response->getBody()->getContents(), true);
-        $this->count = $resp['count'];
-        $this->page = $resp['results'];
-        $this->next = $resp['next'];
+        if (!array_key_exists('count', $resp) && array_key_exists('id', $resp)) {
+            // This is a single entity
+            $this->count = 1;
+            $this->page = [ $resp ];
+            $this->next = null;
+            $this->page_org = $this->page;
+            $this->next_org = $this->next;
+        } else {
+            $this->count = $resp['count'];
+            $this->page = $resp['results'];
+            $this->next = $resp['next'];
+            $this->page_org = $this->page;
+            $this->next_org = $this->next;
+        }
         $this->client = $client;
-        $this->page_org = $this->page;
-        $this->next_org = $this->next;
     }
 
     public function current(): Entity {


### PR DESCRIPTION
This PR introduces a number of small changes:

- Refactor code in Client.php to use `getCollection` or `getSingle`
- Modify constructor of Collection to accept a single item (so URLs like /api/tenancy/tenants/1 can be used instead of /api/tenancy/tenants/?id=1)
- Use correct URLs for collections (`/api/tenancy/tenants redirects` to `/api/tenancy/tenants/` - works but extra request)
- Use correct URLs for single items (`/api/tenancy/tenants/1` instead of `/api/tenancy/tenants/?id=1`)

The main purpose here was to allow users of the client to call `getCollection` or `getSingle` directly, for cases where the correct endpoint has not been defined.  For example, there is no `getRegions` in this client. but a user can call `getCollection('/api/dcim/regions/')` instead now.